### PR TITLE
Build failure fixes and minor cleanups to improve logging

### DIFF
--- a/HabSampleService.cs
+++ b/HabSampleService.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Reflection;
 using System.ServiceProcess;
+using System;
 
 namespace HabitatSample
 {
@@ -53,12 +54,9 @@ namespace HabitatSample
             {
                 statusFileDir = ConfigurationManager.AppSettings["statusFileDir"];
             }
-            using (FileStream fs = new FileStream(Path.Combine(statusFileDir, "status.txt"), FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            using (var tw = new StreamWriter(Path.Combine(statusFileDir, "status.txt"), true))
             {
-                using (StreamWriter sw = new StreamWriter(fs, System.Text.Encoding.UTF8))
-                {
-                    sw.WriteLine(message);
-                }
+                tw.WriteLine(DateTime.Now.ToString() + ": " + message);
             }
         }
 

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,3 @@
+# Default configuration
+
+service_name = "HabSampleService"

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -3,7 +3,7 @@ if(Test-Path bin) { Remove-Item bin -Recurse -Force }
 New-Item -Name bin -ItemType Junction -target "{{pkg.path}}/bin" | Out-Null
 
 # Add the Windows Service
-if((Get-Service HabSampleService -ErrorAction SilentlyContinue) -eq $null) {
+if((Get-Service {{cfg.service_name}} -ErrorAction SilentlyContinue) -eq $null) {
 	$binPath = (Resolve-Path "{{pkg.svc_path}}/bin/{{pkg.name}}.exe").Path
-    &$env:systemroot\system32\sc.exe create HabSampleService binpath= $binPath
+    &$env:systemroot\system32\sc.exe create {{cfg.service_name}} binpath= $binPath
 }

--- a/habitat/hooks/post-stop
+++ b/habitat/hooks/post-stop
@@ -1,5 +1,5 @@
-﻿if($(Get-Service HabSampleService).Status -ne "Stopped") {
+﻿if($(Get-Service {{cfg.service_name}}).Status -ne "Stopped") {
     Write-Host "{{pkg.name}} stopping..."
-    Stop-Service HabSampleService
+    Stop-Service {{cfg.service_name}}
     Write-Host "{{pkg.name}} has stopped"
 }

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,7 +1,7 @@
 ﻿Copy-Item "{{pkg.svc_config_path}}\windows-service-sample.exe.config" "{{pkg.svc_path}}\bin" -Force
 
-Start-Service HabSampleService
+Start-Service {{cfg.service_name}}
 Write-Host "{{pkg.name}} is running"
-while($(Get-Service HabSampleService).Status -eq "Running") {
+while($(Get-Service {{cfg.service_name}}).Status -eq "Running") {
     Start-Sleep -Seconds 1
 }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -1,8 +1,7 @@
 ﻿$pkg_name="windows-service-sample"
 $pkg_origin="mwrock"
-$pkg_version="0.1.0"
-$pkg_source="nosuchfile.tar.gz"
-$pkg_maintainer="Matt Wrock"
+$pkg_version="0.2.0"
+$pkg_maintainer="Matt Wrock, Murali Valluri"
 $pkg_license=@('MIT')
 $pkg_description="A sample .NET Windows Service"
 $pkg_bin_dirs=@("bin")


### PR DESCRIPTION
There was build failure when I ran this sample. 
So I've fixed that part and also added default.toml file to store the service name. While doing this, also did minor change to code to also log timestamp.